### PR TITLE
Deleted overidden resolve object in module.exports

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,9 +3,6 @@ const path = require('path');
 
 module.exports = {
     mode: 'development',
-    resolve: {
-        extensions: ['.js', '.jsx']
-    },
     module: {
         rules: [
             {


### PR DESCRIPTION
I deleted the first resolve object in module.exports object because its overridden later on in the file and is insignificant.